### PR TITLE
Added colors for the List Filter Widget.

### DIFF
--- a/themes/Hyper Term Black-color-theme.json
+++ b/themes/Hyper Term Black-color-theme.json
@@ -67,7 +67,10 @@
 		"titleBar.activeBackground": "#000000",
 		"titleBar.activeForeground": "#9da5b4",
 		"titleBar.inactiveBackground": "#000000",
-		"titleBar.inactiveForeground": "#6B717D"
+		"titleBar.inactiveForeground": "#6B717D",
+		"listFilterWidget.background": "#000000", 
+		"listFilterWidget.outline": "#4D78CC",
+		"listFilterWidget.noMatchesOutline": "#c24038"
 	  },
 	  "tokenColors": [
 		{


### PR DESCRIPTION
VSCode has a new feature out this month that allows for a user to search the text of file/directory names in the explorer. With the values unset, text matching the searched text is highlighted black and not visible to the user. This fix highlights the text blue. 

If you want to choose different colors, I totally understand. I just used my best judgement and the colors you had used before to do the fix. 

More about this feature can be found [here](https://code.visualstudio.com/updates/v1_31#_new-tree-widget).

I am such a huge fan of this theme and use it alongside Hyper at work and at home. Thank you so much.